### PR TITLE
Filter out AD B2B created accounts from Entra Connect Sync to avoid on-premises AD being authoritative, bug fixes

### DIFF
--- a/B2B-AAD-to-AD-Sync.ps1
+++ b/B2B-AAD-to-AD-Sync.ps1
@@ -133,7 +133,7 @@ If ($CreateMissingShadowAccounts -eq $true)
 {
     ForEach($key in $($UsersInB2BGroupHash.keys))
         {
-        $samaccountname = (-join $TenantGuestUsersHash[$key].userprincipalname[0..19]).TrimEnd('.') # sAMAccountName must be no longer than 20 characters long and final character cannot be a period https://learn.microsoft.com/en-us/archive/technet-wiki/11216.active-directory-requirements-for-creating-objects#objects-with-samaccountname-attribute
+        $samaccountname = (-join $TenantGuestUsersHash[$key].userprincipalname.Split("@")[0][0..19]).TrimEnd('.') # sAMAccountName must be no longer than 20 characters long and final character cannot be a period https://learn.microsoft.com/en-us/archive/technet-wiki/11216.active-directory-requirements-for-creating-objects#objects-with-samaccountname-attribute
         $displayname = $TenantGuestUsersHash[$key].userprincipalname.Split('#')[0]
         # generate random password
         $bytes = New-Object Byte[] 32


### PR DESCRIPTION
It's necessary to filter out AD B2B created accounts from Entra Connect Sync to avoid on-premises AD being authoritative.

(https://learn.microsoft.com/en-us/microsoft-identity-manager/microsoft-identity-manager-2016-graph-b2b-scenario#configure-ad-and-microsoft-entra-connect-to-exclude-users-added-from-microsoft-entra-id)

The script doesn't mention or do this, but it's easy to achieve by setting the 'adminDescription' attribute to any value starting with 'User_'

Also the script fails where a samAccountName is created with fewer than 20 characters, or ends in a period, both of which are invalid. It is also created with the domain part of the UPN. These are quick fixes.

https://learn.microsoft.com/en-us/archive/technet-wiki/11216.active-directory-requirements-for-creating-objects#objects-with-samaccountname-attribute

Also the DisplayName variable name incorrectly includes 'Value', resulting in empty DisplayName.