### PR TITLE
Disable confirmation prompt to remove user to allow unattended operation

### DIFF
--- a/B2B-AAD-to-AD-Sync.ps1
+++ b/B2B-AAD-to-AD-Sync.ps1
@@ -182,7 +182,7 @@ If ($RestoreDisabledAccounts -eq $true)
             }
             ElseIf ($DeleteOrphanedShadowAccounts = $true)
             {
-                Get-AdUser -Filter {UserPrincipalName -eq $shadow} -SearchBase $ShadowAccountOU | Remove-AdUser
+                Get-AdUser -Filter {UserPrincipalName -eq $shadow} -SearchBase $ShadowAccountOU | Remove-AdUser -Confirm:$false
             }
         }
   }


### PR DESCRIPTION
When running the script at present, the user is prompted to confirm user deletion, preventing the script being run unattended.

This patch removes that limitation.